### PR TITLE
Fix: add missing route to Html::a() URL array in notAllowedIp view

### DIFF
--- a/src/views/allowed-ips/notAllowedIp.php
+++ b/src/views/allowed-ips/notAllowedIp.php
@@ -14,7 +14,7 @@ $this->title = Yii::t('mfa', 'Not allowed IP');
 </p>
 
 <p align="center">
-    <b><?= Html::a(Yii::t('mfa', 'Add this IP to the list of allowed IPs'), ['token' => 'send']) ?></b>
+    <b><?= Html::a(Yii::t('mfa', 'Add this IP to the list of allowed IPs'), ['not-allowed-ip', 'token' => 'send']) ?></b>
 </p>
 
 <p align="center">


### PR DESCRIPTION
 Html::a() passed ['token' => 'send'] as the URL — a Yii2 route array without the required route element at index 0. This caused Undefined array key 0 in BaseUrl::toRoute() whenever a user hit the "not allowed IP" page and tried to add their IP.
 The fix adds 'not-allowed-ip' as the route, producing ['not-allowed-ip', 'token' => 'send'], which correctly generates a link back to AllowedIpsController::actionNotAllowedIp with ?token=send.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Add this IP to the list of allowed IPs” link so it points to the correct page while preserving the existing token parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->